### PR TITLE
Misc. changes: Docker image and Schema version 96

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@
 
 FROM ensemblorg/ensembl-hive
 
-# Install know Perl dependencies with apt (faster than CPAN)
+# Install known guiHive Perl dependencies with apt (faster than CPAN)
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
  && apt-get install libhtml-parser-perl libhtml-template-perl libjson-perl libjson-pp-perl liburi-perl -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@
 FROM ensemblorg/ensembl-hive
 
 # Install know Perl dependencies with apt (faster than CPAN)
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
  && apt-get install libhtml-parser-perl libhtml-template-perl libjson-perl libjson-pp-perl liburi-perl -y \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,8 @@ RUN buildDeps=' \
     && apt-get update -y \
     && apt-get install -y $buildDeps \
     && rm -rf /var/lib/apt/lists/* \
-    && cpanm --installdeps --with-recommends /repo/guiHive \
-    && cd /repo/guiHive/server && go build \
+    && cpanm --installdeps --with-recommends $DEPLOY_LOCATION \
+    && cd $DEPLOY_LOCATION/server && go build \
     && apt-get purge -y --auto-remove $buildDeps
 
 EXPOSE 8080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,25 +7,29 @@
 
 FROM ensemblorg/ensembl-hive
 
-# Install known guiHive Perl dependencies with apt (faster than CPAN)
+# Install common utilities and known guiHive Perl dependencies with apt (faster than CPAN)
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
- && apt-get install libhtml-parser-perl libhtml-template-perl libjson-perl libjson-pp-perl liburi-perl -y \
+ && apt-get install curl git libhtml-parser-perl libhtml-template-perl libjson-perl libjson-pp-perl liburi-perl -y \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG DEPLOY_LOCATION=/repo/guiHive
 RUN curl -L https://raw.githubusercontent.com/Ensembl/guiHive/server/guihive-deploy.sh | bash
 
-# Wrap the cpan and compilation phases with apt-get install/purge to keep the image small
+# Install guiHive and eHive Perl dependencies (across *all* versions) using eHive's helper scripts
+ARG EHIVE_TMP_CHECKOUT=$DEPLOY_LOCATION/ensembl-hive-tmp
+RUN mkdir $EHIVE_TMP_CHECKOUT \
+    && GIT_DIR=$DEPLOY_LOCATION/clones/ensembl-hive GIT_WORK_TREE=$EHIVE_TMP_CHECKOUT git checkout -qf master \
+    && $EHIVE_TMP_CHECKOUT/docker/setup_cpan.Ubuntu-16.04.sh $DEPLOY_LOCATION $DEPLOY_LOCATION/ensembl-hive/* \
+    && rm -rf $EHIVE_TMP_CHECKOUT
+
+# Wrap the compilation phase with apt-get install/purge to keep the image small
 RUN buildDeps=' \
       golang \
-      cpanminus \
-      build-essential \
     ' \
     && apt-get update -y \
     && apt-get install -y $buildDeps \
     && rm -rf /var/lib/apt/lists/* \
-    && cpanm --installdeps --with-recommends $DEPLOY_LOCATION \
     && cd $DEPLOY_LOCATION/server && go build \
     && apt-get purge -y --auto-remove $buildDeps
 

--- a/guihive-deploy.sh
+++ b/guihive-deploy.sh
@@ -79,6 +79,7 @@ safe_symlink () {
 
 trim_ehive_repo () {
   # $dir
+  rm -rf "$1/docker"
   rm -rf "$1/docs"
   rm -rf "$1/wrappers"
   rm -rf "$1/scripts"

--- a/guihive-deploy.sh
+++ b/guihive-deploy.sh
@@ -164,7 +164,8 @@ link_guihive_version "90" "89"
 link_guihive_version "92" "91"
 link_guihive_version "93" "91"  # even though the change in procedures.mysql is already pushed at sql_schema_94_start^4
 link_guihive_version "94" "91"
-link_guihive_version "95" "91" "master"
+link_guihive_version "95" "91"
+link_guihive_version "96" "91" "master"
 
 trap - EXIT
 

--- a/guihive-dev-deploy.sh
+++ b/guihive-dev-deploy.sh
@@ -154,7 +154,8 @@ link_guihive_version "90" "89"
 link_guihive_version "92" "91"
 link_guihive_version "93" "91"  # even though the change in procedures.mysql is already pushed at sql_schema_94_start^4
 link_guihive_version "94" "91"
-link_guihive_version "95" "91" "master"
+link_guihive_version "95" "91"
+link_guihive_version "96" "91" "master"
 
 trap - EXIT
 


### PR DESCRIPTION
This PR is a mixed bag of several unrelated changes. Let me know if you want me to break it down.

- Added the eHive schema version 96
- Make sure the guiHive docker has the Perl dependencies for *all* eHive versions (not just the latest version)
- Clean-up / tidy-up of the Dockerfile and the image