### PR TITLE
Smaller docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,16 +12,24 @@ RUN apt-get install -y golang
 ADD server /tmp/server
 RUN cd /tmp/server && go build
 
+# Deploy all the guiHive and eHive checkouts
+FROM alpine:3.9.4 AS deployer
+RUN apk add git bash
+ADD guihive-deploy.sh /tmp/guiHive/
+RUN bash /tmp/guiHive/guihive-deploy.sh
+RUN rm -rf /tmp/guiHive/clones
+
 FROM ensemblorg/ensembl-hive
 
 # Install common utilities and known guiHive Perl dependencies with apt (faster than CPAN)
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
- && apt-get install curl git libhtml-parser-perl libhtml-template-perl libjson-perl libjson-pp-perl liburi-perl -y \
+ && apt-get install -y --no-install-recommends \
+            libhtml-parser-perl libhtml-template-perl libjson-perl libjson-pp-perl liburi-perl \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG DEPLOY_LOCATION=/repo/guiHive
-RUN curl -L https://raw.githubusercontent.com/Ensembl/guiHive/server/guihive-deploy.sh | bash
+COPY --from=deployer /tmp/guiHive $DEPLOY_LOCATION
 
 # Install guiHive and eHive Perl dependencies (across *all* versions) using eHive's helper scripts
 RUN /repo/ensembl-hive/docker/setup_cpan.Ubuntu-16.04.sh $DEPLOY_LOCATION $DEPLOY_LOCATION/ensembl-hive/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,11 +24,7 @@ ARG DEPLOY_LOCATION=/repo/guiHive
 RUN curl -L https://raw.githubusercontent.com/Ensembl/guiHive/server/guihive-deploy.sh | bash
 
 # Install guiHive and eHive Perl dependencies (across *all* versions) using eHive's helper scripts
-ARG EHIVE_TMP_CHECKOUT=$DEPLOY_LOCATION/ensembl-hive-tmp
-RUN mkdir $EHIVE_TMP_CHECKOUT \
-    && GIT_DIR=$DEPLOY_LOCATION/clones/ensembl-hive GIT_WORK_TREE=$EHIVE_TMP_CHECKOUT git checkout -qf master \
-    && $EHIVE_TMP_CHECKOUT/docker/setup_cpan.Ubuntu-16.04.sh $DEPLOY_LOCATION $DEPLOY_LOCATION/ensembl-hive/* \
-    && rm -rf $EHIVE_TMP_CHECKOUT
+RUN /repo/ensembl-hive/docker/setup_cpan.Ubuntu-16.04.sh $DEPLOY_LOCATION $DEPLOY_LOCATION/ensembl-hive/*
 
 COPY --from=go_builder /tmp/server/server $DEPLOY_LOCATION/server/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,16 @@
 # This is a Dockerfile to run a guiHive server in a container
 #
-# docker build -t guihive .
+# docker build -t guihive -f docker/Dockerfile .
 #
 # docker run --name guihive_server -p 8081:8080 -d guihive	## Start the server. Port mapping = external:internal
 # docker run -p 8082:8080 -it guihive bash			## If you need to do any prior maintenance/tuning - do it in bash, then manually run the CMD below.
+
+# Build the server
+FROM ubuntu:16.04 AS go_builder
+RUN apt-get update -y
+RUN apt-get install -y golang
+ADD server /tmp/server
+RUN cd /tmp/server && go build
 
 FROM ensemblorg/ensembl-hive
 
@@ -23,15 +30,7 @@ RUN mkdir $EHIVE_TMP_CHECKOUT \
     && $EHIVE_TMP_CHECKOUT/docker/setup_cpan.Ubuntu-16.04.sh $DEPLOY_LOCATION $DEPLOY_LOCATION/ensembl-hive/* \
     && rm -rf $EHIVE_TMP_CHECKOUT
 
-# Wrap the compilation phase with apt-get install/purge to keep the image small
-RUN buildDeps=' \
-      golang \
-    ' \
-    && apt-get update -y \
-    && apt-get install -y $buildDeps \
-    && rm -rf /var/lib/apt/lists/* \
-    && cd $DEPLOY_LOCATION/server && go build \
-    && apt-get purge -y --auto-remove $buildDeps
+COPY --from=go_builder /tmp/server/server $DEPLOY_LOCATION/server/
 
 EXPOSE 8080
 


### PR DESCRIPTION
Like in Ensembl/ensembl-hive#137 I have transformed the Dockerfile to do a multi-stages build. Overall it brings a clean separation between several stages of the builds, and allows only selecting the relevant files from each stage without having to clean stuff up in the same command with `&&`.
The resulting image is now just 70MB heavier than the parent eHive image instead of 166MB before, and better utilizes the build cache.
Note that the build context is also expected to be different and I will have to change this on the Docker Hub