### PR TITLE
Fix multiple field update bug

### DIFF
--- a/javascript/ajax.js
+++ b/javascript/ajax.js
@@ -927,8 +927,7 @@ function buildURL(obj, callback) {
             function(x) {
                 obj.add(new Option(x, x, true));
                 obj.value = x;
-                $(obj).change();
-                return buildURL(obj, callback)
+                $(obj).change(); //will trigger a second call to update_db with new value
             }
         );
         return;


### PR DESCRIPTION
Further testing of PR #9 revealed a bug where multiple fields would be updated when using the custom values dialog. (For example, update analysis_capacity using custom values, then update hive_capacity using custom values. In that case, both analysis_capacity and hive_capacity would be set to the value entered for hive_capacity). The issue appeared to be with the recursive buildURL call, which turns out to be unnecessary. Thanks again to @azangru for Javascript advice.