### PR TITLE
copyright fixes and 2020 copyright update for db_version/NN branches

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       identification within third-party archives.
 
    Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-   Copyright [2016] EMBL-European Bioinformatics Institute
+   Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
   </div>
   
   <div class="footer">
-    <p>Copyright (c) 2016 The Ensembl Team. Please send any comment or bug report to ehive-users@ebi.ac.uk</p>
+    <p>Please send any comment or bug report to ehive-users@ebi.ac.uk</p>
   </div>
 
 </body>

--- a/javascript/ajax.js
+++ b/javascript/ajax.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/analysis_summary.js
+++ b/javascript/analysis_summary.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/bubblesCloud.js
+++ b/javascript/bubblesCloud.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/bubbles_cloud.js
+++ b/javascript/bubbles_cloud.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/hBarChart.js
+++ b/javascript/hBarChart.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/hStackedBarChart.js
+++ b/javascript/hStackedBarChart.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/jobs_chart.js
+++ b/javascript/jobs_chart.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/legend.js
+++ b/javascript/legend.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/node_color.js
+++ b/javascript/node_color.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/pieChart.js
+++ b/javascript/pieChart.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/pipeline_diagram.js
+++ b/javascript/pipeline_diagram.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/pipeline_overview.js
+++ b/javascript/pipeline_overview.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/refresh_timer.js
+++ b/javascript/refresh_timer.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/timer.js
+++ b/javascript/timer.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/toggleDiv.js
+++ b/javascript/toggleDiv.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/javascript/views.js
+++ b/javascript/views.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_commands.pl
+++ b/scripts/db_commands.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_connect.pl
+++ b/scripts/db_connect.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_create.pl
+++ b/scripts/db_create.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_fetch_all_analysis.pl
+++ b/scripts/db_fetch_all_analysis.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_fetch_analysis.pl
+++ b/scripts/db_fetch_analysis.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_fetch_jobs.pl
+++ b/scripts/db_fetch_jobs.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_fetch_max_retry_count.pl
+++ b/scripts/db_fetch_max_retry_count.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_fetch_pipeline_params.pl
+++ b/scripts/db_fetch_pipeline_params.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_fetch_resource.pl
+++ b/scripts/db_fetch_resource.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_jobs_form.pl
+++ b/scripts/db_jobs_form.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_load_config.pl
+++ b/scripts/db_load_config.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_monitor_analysis.pl
+++ b/scripts/db_monitor_analysis.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_refresh_test.pl
+++ b/scripts/db_refresh_test.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_test.pl
+++ b/scripts/db_test.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_update.pl
+++ b/scripts/db_update.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_update2.pl
+++ b/scripts/db_update2.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_update_nonobject.pl
+++ b/scripts/db_update_nonobject.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/lib/analysisInfo.pm
+++ b/scripts/lib/analysisInfo.pm
@@ -1,7 +1,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/lib/hive_extended.pm
+++ b/scripts/lib/hive_extended.pm
@@ -1,7 +1,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/lib/msg.pm
+++ b/scripts/lib/msg.pm
@@ -1,7 +1,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/lib/version_check.pm
+++ b/scripts/lib/version_check.pm
@@ -1,7 +1,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
[ENSCORESW-3372] Copyright fix and 2020 copyright update for the db_version/NN branches. Includes changes beyond those done with the annual_copyright_update.sh script, hence the PR. Once accepted, will cascade-merge up to db_version/91 and push the rest of the branches.
