### PR TITLE
Licensing fixes and 2020 copyright update for the server branch

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [1999-2016] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+   Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+   Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/guihive-deploy.sh
+++ b/guihive-deploy.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 DEFAULT_DEPLOY_LOCATION="$(dirname "$0")"
 DEPLOY_LOCATION=${DEPLOY_LOCATION:-$DEFAULT_DEPLOY_LOCATION}

--- a/guihive-dev-deploy.sh
+++ b/guihive-dev-deploy.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 DEFAULT_DEPLOY_LOCATION="$(dirname "$0")"
 DEPLOY_LOCATION=${DEPLOY_LOCATION:-$DEFAULT_DEPLOY_LOCATION}

--- a/javascript/version_picker.js
+++ b/javascript/version_picker.js
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/scripts/db_version.pl
+++ b/scripts/db_version.pl
@@ -3,7 +3,7 @@
 =pod
 
  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- Copyright [2016] EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/server/debug.go
+++ b/server/debug.go
@@ -1,6 +1,18 @@
-// Copyright 2012 Miguel Pignatelli. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+/* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 // +build debug
 

--- a/server/release.go
+++ b/server/release.go
@@ -1,6 +1,18 @@
-// Copyright 2012 Miguel Pignatelli. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+/* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 // +build !debug
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,5 +1,5 @@
 /* Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-/* Copyright [2016] EMBL-European Bioinformatics Institute
+/* Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/test_dep.pl
+++ b/test_dep.pl
@@ -2,7 +2,8 @@
 
 =pod
 
- Copyright [1999-2016] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Licensing fixes and 2020 annual copyright update for the server branch. Includes changes beyond those automatically made by the annual_copyright_update.sh script, hence the PR. This branch is outside of the db_version/NN cascade merge scheme, so the changes need to be made seperately anyway.