### PR TITLE
Fixed to use official Go image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,14 +6,13 @@
 # docker run -p 8082:8080 -it guihive bash			## If you need to do any prior maintenance/tuning - do it in bash, then manually run the CMD below.
 
 # Build the server
-FROM ubuntu:16.04 AS go_builder
+FROM golang:1.17 AS go_builder
 RUN apt-get update -y
-RUN apt-get install -y golang
 ADD server /tmp/server
 RUN cd /tmp/server && go build
 
 # Deploy all the guiHive and eHive checkouts
-FROM alpine:3.9.4 AS deployer
+FROM alpine AS deployer
 RUN apk add git bash
 ADD guihive-deploy.sh /tmp/guiHive/
 RUN bash /tmp/guiHive/guihive-deploy.sh


### PR DESCRIPTION
## Description

Fixed Dockerfile to use:
- official Go docker image (Go v1.17)
- up-to-date Alpine image

## Benefits

Working up-to-date guiHive Dockerfile

## Possible Drawbacks

None

## Testing

Successfully tested