### PR TITLE
Fixed GitHub links

### DIFF
--- a/guihive-deploy.sh
+++ b/guihive-deploy.sh
@@ -36,10 +36,10 @@ then
     rm -rf "$GUIHIVE_CLONE_LOCATION" "$GUIHIVE_VERSIONS_DIR"
 fi
 
-EHIVE_DEFAULT_SOURCE='git://www.github.com/Ensembl/ensembl-hive'
+EHIVE_DEFAULT_SOURCE='https://www.github.com/Ensembl/ensembl-hive'
 EHIVE_SOURCE=${EHIVE_SOURCE:-$EHIVE_DEFAULT_SOURCE}
 
-GUIHIVE_DEFAULT_SOURCE='git://www.github.com/Ensembl/guiHive'
+GUIHIVE_DEFAULT_SOURCE='https://www.github.com/Ensembl/guiHive'
 GUIHIVE_SOURCE=${GUIHIVE_SOURCE:-$GUIHIVE_DEFAULT_SOURCE}
 
 umask 0002

--- a/guihive-dev-deploy.sh
+++ b/guihive-dev-deploy.sh
@@ -36,10 +36,10 @@ then
     rm -rf "$GUIHIVE_CLONE_LOCATION" "$GUIHIVE_VERSIONS_DIR"
 fi
 
-EHIVE_DEFAULT_SOURCE='git://www.github.com/Ensembl/ensembl-hive'
+EHIVE_DEFAULT_SOURCE='https://www.github.com/Ensembl/ensembl-hive'
 EHIVE_SOURCE=${EHIVE_SOURCE:-$EHIVE_DEFAULT_SOURCE}
 
-GUIHIVE_DEFAULT_SOURCE='git://www.github.com/Ensembl/guiHive'
+GUIHIVE_DEFAULT_SOURCE='https://www.github.com/Ensembl/guiHive'
 GUIHIVE_SOURCE=${GUIHIVE_SOURCE:-$GUIHIVE_DEFAULT_SOURCE}
 
 umask 0002


### PR DESCRIPTION
## Description

Fixed links to GitHub repos into 
- guihive-deploy.sh
- guihive-dev-deploy.sh

## Benefits

Making the deploy scripts work again

## Possible Drawbacks

None

## Testing

Successfully tested