### PR TITLE
Features/update display tab name

### DIFF
--- a/javascript/ajax.js
+++ b/javascript/ajax.js
@@ -21,6 +21,7 @@ var guiHive = {
     version                   : undefined, // The guiHive/Hive version
     pipeline_url              : "",        // The url to connect to the pipeline
                                            // This is the value of $("#db_url") i.e. it is entered by the user
+    pipeline_name             : "eHive - Take control over your eHive Production system",        // Hold the pipeline name part of pipeline_url
     refresh_data_timer        : undefined, // The timer for the next data update
     monitorTimeout            : 30000,     // Time for next data update
                                            // TODO: This has to disappear in favor of refresh_data_timer
@@ -244,6 +245,7 @@ function get_mysql_password(loc_url) {
 
     $("#password-id").modal("hide");
     guiHive.pipeline_url = loc_url;
+    guiHive.pipeline_name = loc_url.split("/").pop();
     connect();
 }
 
@@ -351,6 +353,9 @@ function onSuccess_dbConnect(res) {
 	guiHive.refresh_data_timer.reset();
 	// The number of seconds to refresh is exposed
 	guiHive.refresh_data_timer.div($("#secs_to_refresh"));
+
+    document.title = guiHive.pipeline_name + " -- eHive";
+
 
 	// We draw the pipeline diagram
 	draw_diagram(res.out_msg.graph);

--- a/scripts/db_fetch_jobs.pl
+++ b/scripts/db_fetch_jobs.pl
@@ -111,7 +111,7 @@ sub formJobsInfo {
 		    "6" => $job->when_completed(),
 		    "7" => $job->runtime_msec(),
 		    "8" => $job->controlled_semaphore_id(),
-		    "9" => $msg,
+		    "9" => $msg ? "<pre style='border:none'>$msg</pre>" : "",
 		  };
   }
   my $response = {


### PR DESCRIPTION
Two updates: 
- Display the pipeline name in Browser tab instead of standard message

![image](https://user-images.githubusercontent.com/611039/170714260-d0680a1f-0e31-44af-9b61-39a98bb24511.png)

- Use `<pre>` html tag do fetch error_message - useful for copy/past and display for DC errors. 
 
![image](https://user-images.githubusercontent.com/611039/170714205-ea572acc-cf0a-4067-8da7-b0b42096fbbe.png)
